### PR TITLE
Optimize gas

### DIFF
--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -160,8 +160,7 @@ contract Ballot {
     function winningProposal() public view returns (uint256 winningProposal_) {
         uint256 winningVoteCount = 0;
         Proposal[] memory localProposals = proposals;
-        uint256 proposalsLength = localProposals.length;
-        for (uint256 p = 0; p < proposalsLength; p++) {
+        for (uint256 p = 0; p < localProposals.length; p++) {
             if (localProposals[p].voteCount > winningVoteCount) {
                 winningVoteCount = localProposals[p].voteCount;
                 winningProposal_ = p;

--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -12,10 +12,10 @@ contract Ballot {
     * It will represent a single voter.
     */
     struct Voter {
-        uint112 weight; /// @dev weight is accumulated by delegation
-        bool voted; /// @dev if true, that person already voted
-        address delegate; /// @dev person delegated to
-        uint112 vote; /// @dev index of the voted proposal
+        bool voted; // if true, that person already voted
+        address delegate; // person delegated to
+        uint256 weight; // weight is accumulated by delegation
+        uint256 vote; // index of the voted proposal
     }
 
     /// @dev This is a type for a single proposal.
@@ -23,7 +23,7 @@ contract Ballot {
         /// @dev short name (up to 32 bytes)
         bytes32 name; 
         /// @dev number of accumulated votes
-        uint224 voteCount; 
+        uint256 voteCount; 
     }
 
     /// @dev Stores the `chairperson` address which will be able to give right to vote on proposals.
@@ -136,7 +136,7 @@ contract Ballot {
     * to proposal `proposals[proposal].name`.
     */
     /// @param proposal The proposal index to vote on
-    function vote(uint112 proposal) external {
+    function vote(uint256 proposal) external {
         Voter storage sender = voters[msg.sender];
         require(sender.weight != 0, "Has no right to vote");
         require(!sender.voted, "Already voted.");
@@ -159,10 +159,11 @@ contract Ballot {
     /// @return winningProposal_ The winning proposal index
     function winningProposal() public view returns (uint256 winningProposal_) {
         uint256 winningVoteCount = 0;
-        uint256 proposalsLength = proposals.length;
+        Proposal[] memory localProposals = proposals;
+        uint256 proposalsLength = localProposals.length;
         for (uint256 p = 0; p < proposalsLength; p++) {
-            if (proposals[p].voteCount > winningVoteCount) {
-                winningVoteCount = proposals[p].voteCount;
+            if (localProposals[p].voteCount > winningVoteCount) {
+                winningVoteCount = localProposals[p].voteCount;
                 winningProposal_ = p;
             }
         }

--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -12,10 +12,10 @@ contract Ballot {
     * It will represent a single voter.
     */
     struct Voter {
-        uint256 weight; /// @dev weight is accumulated by delegation
+        uint112 weight; /// @dev weight is accumulated by delegation
         bool voted; /// @dev if true, that person already voted
         address delegate; /// @dev person delegated to
-        uint256 vote; /// @dev index of the voted proposal
+        uint112 vote; /// @dev index of the voted proposal
     }
 
     /// @dev This is a type for a single proposal.
@@ -23,7 +23,7 @@ contract Ballot {
         /// @dev short name (up to 32 bytes)
         bytes32 name; 
         /// @dev number of accumulated votes
-        uint256 voteCount; 
+        uint224 voteCount; 
     }
 
     /// @dev Stores the `chairperson` address which will be able to give right to vote on proposals.
@@ -136,7 +136,7 @@ contract Ballot {
     * to proposal `proposals[proposal].name`.
     */
     /// @param proposal The proposal index to vote on
-    function vote(uint256 proposal) external {
+    function vote(uint112 proposal) external {
         Voter storage sender = voters[msg.sender];
         require(sender.weight != 0, "Has no right to vote");
         require(!sender.voted, "Already voted.");
@@ -159,7 +159,8 @@ contract Ballot {
     /// @return winningProposal_ The winning proposal index
     function winningProposal() public view returns (uint256 winningProposal_) {
         uint256 winningVoteCount = 0;
-        for (uint256 p = 0; p < proposals.length; p++) {
+        uint256 proposalsLength = proposals.length;
+        for (uint256 p = 0; p < proposalsLength; p++) {
             if (proposals[p].voteCount > winningVoteCount) {
                 winningVoteCount = proposals[p].voteCount;
                 winningProposal_ = p;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -28,7 +28,7 @@ const config: HardhatUserConfig = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 15,
+        runs: 10,
       },
     },
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -23,7 +23,15 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 // Go to https://hardhat.org/config/ to learn more
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.4",
+  solidity: {
+    version: "0.8.4",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 15,
+      },
+    },
+  },
   paths: { tests: "tests" },
   networks: {
     ropsten: {

--- a/tests/Ballot/Ballot.ts
+++ b/tests/Ballot/Ballot.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
+import { Signer } from "ethers";
 import { ethers } from "hardhat";
 // eslint-disable-next-line node/no-missing-import
-import { Ballot } from "../../typechain/index";
+import { Ballot, Ballot__factory } from "../../typechain";
 
 const PROPOSALS = ["Proposal 1", "Proposal 2", "Proposal 3"];
 
@@ -13,18 +14,40 @@ function convertStringArrayToBytes32(array: string[]) {
   return bytes32Array;
 }
 
-async function giveRightToVote(ballotContract: Ballot, voterAddress: any) {
-  const tx = await ballotContract.giveRightToVote(voterAddress);
+async function giveRightToVote(
+  ballotContract: Ballot,
+  voterAddress: any,
+  signer?: Signer
+) {
+  const tx = signer
+    ? await ballotContract.connect(signer).giveRightToVote(voterAddress)
+    : await ballotContract.giveRightToVote(voterAddress);
   await tx.wait();
+}
+
+async function vote(ballotContract: Ballot, signer: Signer, proposal: number) {
+  const tx = await ballotContract.connect(signer).vote(proposal);
+  await tx.wait();
+}
+
+async function delegate(ballotContract: Ballot, signer: Signer, to: string) {
+  const tx = await ballotContract.connect(signer).delegate(to);
+  await tx.wait();
+}
+
+async function winningProposal(ballotContract: Ballot) {
+  await ballotContract.winningProposal();
 }
 
 describe("Ballot", function () {
   let ballotContract: Ballot;
   let accounts: any[];
 
-  this.beforeEach(async function () {
+  beforeEach(async function () {
     accounts = await ethers.getSigners();
-    const ballotFactory = await ethers.getContractFactory("Ballot");
+    const ballotFactory = (await ethers.getContractFactory(
+      "Ballot"
+    )) as Ballot__factory;
     ballotContract = await ballotFactory.deploy(
       convertStringArrayToBytes32(PROPOSALS)
     );
@@ -62,7 +85,8 @@ describe("Ballot", function () {
   describe("when the chairperson interacts with the giveRightToVote function in the contract", function () {
     it("gives right to vote for another address", async function () {
       const voterAddress = accounts[1].address;
-      await giveRightToVote(ballotContract, voterAddress);
+      const tx = await ballotContract.giveRightToVote(voterAddress);
+      await tx.wait();
       const voter = await ballotContract.voters(voterAddress);
       expect(voter.weight.toNumber()).to.eq(1);
     });
@@ -76,7 +100,7 @@ describe("Ballot", function () {
       ).to.be.revertedWith("The voter already voted.");
     });
 
-    it("can not give right to vote for someone that has already voting rights", async function () {
+    it("can not give right to vote for someone that already has voting rights", async function () {
       const voterAddress = accounts[1].address;
       await giveRightToVote(ballotContract, voterAddress);
       await expect(
@@ -86,72 +110,115 @@ describe("Ballot", function () {
   });
 
   describe("when the voter interact with the vote function in the contract", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("should has the right to vote", async function () {
+      await expect(vote(ballotContract, accounts[1], 0)).to.be.revertedWith(
+        "Has no right to vote"
+      );
+    });
+
+    it("should has not already voted", async function () {
+      await vote(ballotContract, accounts[0], 0);
+      await expect(vote(ballotContract, accounts[0], 1)).to.be.revertedWith(
+        "Already voted."
+      );
     });
   });
 
   describe("when the voter interact with the delegate function in the contract", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("should has not already voted", async function () {
+      await vote(ballotContract, accounts[0], 0);
+      await expect(
+        delegate(ballotContract, accounts[0], accounts[1].address)
+      ).to.be.revertedWith("You already voted.");
+    });
+
+    it("can not self-delegate", async function () {
+      await expect(
+        delegate(ballotContract, accounts[0], accounts[0].address)
+      ).to.be.revertedWith("Self-delegation is disallowed.");
     });
   });
 
   describe("when the an attacker interact with the giveRightToVote function in the contract", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("can not give voting rights", async function () {
+      await expect(
+        giveRightToVote(ballotContract, accounts[2].address, accounts[1])
+      ).to.be.revertedWith("Only chairperson can give right to vote.");
     });
   });
 
   describe("when the an attacker interact with the vote function in the contract", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    describe("and the proposal does not exist", function () {
+      it("should revert all the state changes", async function () {
+        await expect(
+          vote(ballotContract, accounts[0], 1337)
+        ).to.be.revertedWith("");
+      });
     });
   });
 
   describe("when the an attacker interact with the delegate function in the contract", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("can not produce loop in delegation", async function () {
+      await giveRightToVote(ballotContract, accounts[1].address);
+      await delegate(ballotContract, accounts[0], accounts[1].address);
+      await expect(
+        delegate(ballotContract, accounts[1], accounts[0].address)
+      ).to.be.revertedWith("Found loop in delegation.");
     });
   });
 
   describe("when someone interact with the winningProposal function before any votes are cast", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("should return the index of the first proposal", async function () {
+      const winningProposal = await ballotContract.winningProposal();
+      expect(winningProposal).to.eq(0);
     });
   });
 
   describe("when someone interact with the winningProposal function after one vote is cast for the first proposal", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("should return the index of the first proposal", async function () {
+      await vote(ballotContract, accounts[0], 0);
+      const winningProposal = await ballotContract.winningProposal();
+      expect(winningProposal).to.eq(0);
     });
   });
 
   describe("when someone interact with the winnerName function before any votes are cast", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("should return the first proposal name", async function () {
+      const winnerName = await ballotContract.winnerName();
+      expect(ethers.utils.parseBytes32String(winnerName)).to.eq("Proposal 1");
     });
   });
 
   describe("when someone interact with the winnerName function after one vote is cast for the first proposal", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("should return the first proposal name", async function () {
+      await vote(ballotContract, accounts[0], 0);
+      const winnerName = await ballotContract.winnerName();
+      expect(ethers.utils.parseBytes32String(winnerName)).to.eq("Proposal 1");
     });
   });
 
   describe("when someone interact with the winningProposal function and winnerName after 5 random votes are cast for the proposals", function () {
-    // TODO
-    it("is not implemented", async function () {
-      throw new Error("Not implemented");
+    it("should return the index and the name of the proposal with highest votes count", async function () {
+      await giveRightToVote(ballotContract, accounts[1].address);
+      await giveRightToVote(ballotContract, accounts[2].address);
+      await giveRightToVote(ballotContract, accounts[3].address);
+      await giveRightToVote(ballotContract, accounts[4].address);
+
+      // Proposal 2 should be the proposal with highest votes count
+      await vote(ballotContract, accounts[0], 0);
+      await vote(ballotContract, accounts[1], 1);
+      await vote(ballotContract, accounts[2], 2);
+      await vote(ballotContract, accounts[3], 2);
+      await vote(ballotContract, accounts[4], 2);
+
+      const winningProposal = await ballotContract.winningProposal();
+      const winnerName = await ballotContract.winnerName();
+      const indexWithHighestVotes = 2;
+      const proposal = await ballotContract.proposals(indexWithHighestVotes);
+
+      expect(winnerName).to.eq(proposal.name);
+      expect(winningProposal).to.eq(indexWithHighestVotes);
+      expect(proposal.voteCount).to.eq(3);
     });
   });
 });


### PR DESCRIPTION
Fixes #2 

I did try to pack up as much as possible the Voter struct with 252 bytes used, now it has only one storage slot instead of 4.

To inspect gas usage, add `REPORT_GAS=true` in your .env file.
Then, run `yarn hardhat test`.

Here is the result before optimization:
![image](https://user-images.githubusercontent.com/21549771/177997568-f5df7d5a-32d4-497e-a901-541481853cd0.png)

Here is the result after optimization:
![image](https://user-images.githubusercontent.com/21549771/177997273-e9b6ce69-6ae9-4dd0-be65-1920924e2584.png)
